### PR TITLE
refactor config directory search to use `$XDG_CONFIG_DIRS`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -180,10 +180,6 @@ impl Config {
             }
         }
 
-        // If no config directory found in XDG_CONFIG_DIRS, fall back to the default
-        // This is still bad, because chances are user refuses to conform to XDG spec.
-        // But what do I know?
-        // - raf
         let default_config_path = dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("~"))
             .join(".config")


### PR DESCRIPTION
- Replaces the use of `dirs::config_dir` with manual handling of the `XDG_CONFIG_DIRS` environment variable to search for the configuration directory We now check all directories listed in `XDG_CONFIG_DIRS` for the existence of the `hyprlauncher` config folder. If no directory is found, it falls back to the default value of `~/.config/hyprlauncher`.
- Removes some unnecessary whitespaces (better handled with editorconfig)

I think the `dirs` crate should be removed because it's a low lever wrapper with almost no benefit, but I don't want to impose further changes.