### PR TITLE
fix: set theme css to higher priority

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -11,7 +11,7 @@ use gtk4::{
     subclass::prelude::*,
     Application, ApplicationWindow, Box as GtkBox, CssProvider, Label, ListView, Orientation,
     ScrolledWindow, SearchEntry, SignalListItemFactory, SingleSelection,
-    STYLE_PROVIDER_PRIORITY_APPLICATION,
+    STYLE_PROVIDER_PRIORITY_USER,
 };
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use std::{cell::RefCell, process::Command, rc::Rc};
@@ -213,7 +213,7 @@ impl LauncherWindow {
             gtk4::style_context_add_provider_for_display(
                 &native.display(),
                 &css_provider,
-                STYLE_PROVIDER_PRIORITY_APPLICATION,
+                STYLE_PROVIDER_PRIORITY_USER,
             );
         }
         log!(
@@ -429,7 +429,7 @@ impl LauncherWindow {
             gtk4::style_context_add_provider_for_display(
                 &native.display(),
                 &css_provider,
-                STYLE_PROVIDER_PRIORITY_APPLICATION,
+                STYLE_PROVIDER_PRIORITY_USER,
             );
         }
 


### PR DESCRIPTION
Hello,

when the user is using a gtk theme, it could lead to the values not being loaded properly because the theme may use a higher priority than `APPLICATION`, so I switched it to  `USER` which has the highest priority

I also tried `SETTINGS` priority, which should be higher than `THEME` (which I guess themes are using) however that did lead to the same results that the theme overrides some css properties

(The GTK theme I used was https://github.com/Fausto-Korpsvart/Kanagawa-GKT-Theme, I guess it depends on what values the theme itself provides? I don't know much about gtk themeing, but I think this should make it so that no gtk theme can override the css if use_gtk_colors is false and do just the same if use_gtk_colors is true)

Here it shows the theme overriding some settings, even though use_gtk_colors is set to false:


<details>
  <summary>application priority</summary>

![application](https://github.com/user-attachments/assets/3f96bb44-bf38-4987-81ca-08510e1ed26b)

</details>

<details>
  <summary>user priority</summary>

![user](https://github.com/user-attachments/assets/de36e0d4-b3e0-4d8c-b5ff-7d6063ea2060)

</details>
