### PR TITLE
fix: edit desktop paths so that user overrides are properly recognized

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -29,10 +29,10 @@ pub enum EntryType {
 static HEATMAP_PATH: &str = "~/.local/share/hyprlauncher/heatmap.json";
 
 static DESKTOP_PATHS: &[&str] = &[
-    "~/.local/share/applications",
     "/usr/share/applications",
     "/usr/local/share/applications",
     "/var/lib/flatpak/exports/share/applications",
+    "~/.local/share/applications",
     "~/.local/share/flatpak/exports/share/applications",
 ];
 


### PR DESCRIPTION
In the DESKTOP_PATHS, user overrides should come last so the launcher correctly recognizes them. For example, to override an Electron app to use Wayland, a user has to override the .desktop file in their local folder. This will only be recognized if the user's custom paths come last when scanned. 

Before:
![image](https://github.com/user-attachments/assets/9090a03d-a5f5-4cd8-ae2f-d4990db09436)

After:
![image](https://github.com/user-attachments/assets/f7849719-95fd-4423-a51b-1e57548fc2ad)

