### PR TITLE
Add Locale Support to Hyprlauncher

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -217,12 +217,11 @@ fn parse_desktop_entry(path: &std::path::Path) -> Option<AppEntry> {
     let lang = lang.split('.').next().unwrap_or_default();
 
     let get_localized = |base_key: &str| -> Option<String> {
-		if section.has_attr_with_param(base_key,lang) {
-        	section.attr_with_param(base_key,lang).map(String::from)
-       	} else {
-	        // fall back
-	        section.attr(base_key).map(String::from)
-	    }
+        if section.has_attr_with_param(base_key, lang) {
+            section.attr_with_param(base_key, lang).map(String::from)
+        } else {
+            section.attr(base_key).map(String::from)
+        }
     };
 
     let name = get_localized("Name")?;

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -239,7 +239,6 @@ fn parse_desktop_entry(path: &std::path::Path) -> Option<AppEntry> {
         .or_else(|| get_localized("GenericName"))
         .unwrap_or_default();
 
-
     let keywords = section
         .attr("Keywords")
         .map(|k| {


### PR DESCRIPTION
Now correctly reads locale params from destop entries.

Before:
![image](https://github.com/user-attachments/assets/c001bdc4-974f-49d3-987e-886abf005bfe)

After:
![image](https://github.com/user-attachments/assets/fe105b01-36ed-470e-ae86-6b9b9f693311)
